### PR TITLE
Add two options to Xen tools for gpu scheduling

### DIFF
--- a/tools/libxl/libxl_dm.c
+++ b/tools/libxl/libxl_dm.c
@@ -531,7 +531,7 @@ static int libxl__build_device_model_args_old(libxl__gc *gc,
                     libxl__sprintf(gc, "%d", b_info->u.hvm.vgt_high_gm_sz), NULL);
             }
             if (b_info->u.hvm.vgt_fence_sz) {
-                flexarray_vappend(dm_args, "-vgt_fenc_sz",
+                flexarray_vappend(dm_args, "-vgt_fence_sz",
                     libxl__sprintf(gc, "%d", b_info->u.hvm.vgt_fence_sz), NULL);
             }
             if (b_info->u.hvm.vgt_primary != -1) {
@@ -545,6 +545,14 @@ static int libxl__build_device_model_args_old(libxl__gc *gc,
             if (b_info->u.hvm.vgt_monitor_config_file) {
                 flexarray_vappend(dm_args, "-vgt_monitor_config_file",
                     libxl__sprintf(gc, "%s", b_info->u.hvm.vgt_monitor_config_file), NULL);
+            }
+            if (b_info->u.hvm.vgt_priority) {
+                flexarray_vappend(dm_args, "-vgt_priority",
+                    libxl__sprintf(gc, "%d", b_info->u.hvm.vgt_priority), NULL);
+            }
+            if (b_info->u.hvm.tbs_period_ms) {
+                flexarray_vappend(dm_args, "-tbs_period_ms",
+                    libxl__sprintf(gc, "%d", b_info->u.hvm.tbs_period_ms), NULL);
             }
         } else {
             switch (b_info->u.hvm.vga.kind) {
@@ -958,6 +966,19 @@ static int libxl__build_device_model_args_new(libxl__gc *gc,
                 flexarray_vappend(dm_args, "-vgt_monitor_config_file",
                     libxl__sprintf(gc, "%s", b_info->u.hvm.vgt_monitor_config_file), NULL);
             }
+            if (b_info->u.hvm.vgt_priority) {
+                flexarray_vappend(dm_args, "-vgt_priority",
+                    libxl__sprintf(gc, "%d", b_info->u.hvm.vgt_priority), NULL);
+            }
+            if (b_info->u.hvm.tbs_period_ms) {
+                flexarray_vappend(dm_args, "-tbs_period_ms",
+                    libxl__sprintf(gc, "%d", b_info->u.hvm.tbs_period_ms), NULL);
+            }
+#if 1
+			flexarray_vappend(dm_args, "-D",
+							  libxl__sprintf(gc, " /tmp/qemu-debug.log"),
+							  NULL);
+#endif
         } else {
             switch (b_info->u.hvm.vga.kind) {
             case LIBXL_VGA_INTERFACE_TYPE_STD:

--- a/tools/libxl/libxl_types.idl
+++ b/tools/libxl/libxl_types.idl
@@ -488,6 +488,8 @@ libxl_domain_build_info = Struct("domain_build_info",[
                                        ("vgt_primary",      VgtInt),
                                        ("vgt_cap",      VgtInt),
                                        ("vgt_monitor_config_file", string),
+                                       ("vgt_priority",     VgtInt),
+                                       ("tbs_period_ms",    VgtInt),
                                        ("vnc",              libxl_vnc_info),
                                        # keyboard layout, default is en-us keyboard
                                        ("keymap",           string),

--- a/tools/libxl/xl_cmdimpl.c
+++ b/tools/libxl/xl_cmdimpl.c
@@ -2276,6 +2276,10 @@ skip_vfb:
             b_info->u.hvm.vgt_cap = l;
 
         xlu_cfg_replace_string(config, "vgt_monitor_config_file", &b_info->u.hvm.vgt_monitor_config_file, 0);
+        if (!xlu_cfg_get_long(config, "vgt_priority", &l, 0))
+            b_info->u.hvm.vgt_priority = l;
+        if (!xlu_cfg_get_long(config, "tbs_period_ms", &l, 0))
+            b_info->u.hvm.tbs_period_ms = l;
 
         xlu_cfg_replace_string (config, "keymap", &b_info->u.hvm.keymap, 0);
         xlu_cfg_get_defbool (config, "spice", &b_info->u.hvm.spice.enable, 0);


### PR DESCRIPTION
    This patch supports to set a priority and period time to a guest VM.
    -vgt_prioirity : 1~3 (low ~ high priority)
    -tbs_period_ms : 1~15 (1ms ~ 15ms)

Change-Id: Ic992adce6e8ec44c0bd2ef191d9310d775eeaf0

(Credits to @blue236 too, I just wanted this change to be merged. When will it be in upstream?)